### PR TITLE
Internal: Bump CKBox and React dependencies

### DIFF
--- a/collaboration-comments-outside-of-editor/package.json
+++ b/collaboration-comments-outside-of-editor/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations"
   },
   "devDependencies": {

--- a/collaboration-editor-classic/package.json
+++ b/collaboration-editor-classic/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations"
   },
   "devDependencies": {

--- a/collaboration-for-angular/package.json
+++ b/collaboration-for-angular/package.json
@@ -16,7 +16,7 @@
     "@angular/core": "^18.1.2",
     "@angular/forms": "^18.1.2",
     "@angular/platform-browser": "^18.1.2",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "@ckeditor/ckeditor5-angular": "9.1.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",

--- a/collaboration-for-next/app/page.js
+++ b/collaboration-for-next/app/page.js
@@ -6,8 +6,6 @@
 import dynamic from 'next/dynamic';
 const CKEditorComponent = dynamic( () => import( '@/components/ckeditor' ), { ssr: false } );
 
-// import { default as CKEditorComponent } from '@/components/ckeditor';
-
 export default function App() {
 	return (
 		<div>

--- a/collaboration-for-next/next.config.mjs
+++ b/collaboration-for-next/next.config.mjs
@@ -5,7 +5,6 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	swcMinify: false,
 	output: 'export',
 	distDir: 'build',
 	basePath: '',

--- a/collaboration-for-next/package.json
+++ b/collaboration-for-next/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "9.5.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations",
     "ckeditor5-premium-features": "45.2.0",
     "next": "14.2.26",
-    "react": "^18"
+    "react": "^19"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/collaboration-for-react/package.json
+++ b/collaboration-for-react/package.json
@@ -5,12 +5,12 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "9.5.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19",
+    "react-dom": "^19"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/collaboration-for-vue/package.json
+++ b/collaboration-for-vue/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-vue": "7.3.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "globals": "^16.2.0",
     "husky": "^8.0.2",
     "lint-staged": "^8.1.5",
-    "react": "^18.3.1",
     "typescript": "~5.5.4",
     "vue-eslint-parser": "^10.1.3"
   },

--- a/real-time-collaboration-comments-outside-of-editor/package.json
+++ b/real-time-collaboration-comments-outside-of-editor/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations"
   },
   "devDependencies": {

--- a/real-time-collaboration-editor-classic/package.json
+++ b/real-time-collaboration-editor-classic/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0"
+    "ckbox": "^2.8.0"
   },
   "devDependencies": {
     "vite": "^5.3.5"

--- a/real-time-collaboration-editor-document/package.json
+++ b/real-time-collaboration-editor-document/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0"
+    "ckbox": "^2.8.0"
   },
   "devDependencies": {
     "vite": "^5.3.5"

--- a/real-time-collaboration-editor-multi-root-for-react/package.json
+++ b/real-time-collaboration-editor-multi-root-for-react/package.json
@@ -5,12 +5,12 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "9.5.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19",
+    "react-dom": "^19"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/real-time-collaboration-editor-multi-root/package.json
+++ b/real-time-collaboration-editor-multi-root/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5-collaboration-samples-integrations": "file:../integrations"
   },
   "devDependencies": {

--- a/real-time-collaboration-for-angular/package.json
+++ b/real-time-collaboration-for-angular/package.json
@@ -16,7 +16,7 @@
     "@angular/core": "^18.1.2",
     "@angular/forms": "^18.1.2",
     "@angular/platform-browser": "^18.1.2",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "@ckeditor/ckeditor5-angular": "9.1.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",

--- a/real-time-collaboration-for-next/package.json
+++ b/real-time-collaboration-for-next/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "9.5.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
     "next": "14.2.26",
-    "react": "^18"
+    "react": "^19"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/real-time-collaboration-for-react/package.json
+++ b/real-time-collaboration-for-react/package.json
@@ -5,11 +5,11 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "9.5.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19",
+    "react-dom": "^19"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/real-time-collaboration-for-vue/package.json
+++ b/real-time-collaboration-for-vue/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-vue": "7.3.0",
-    "ckbox": "^2.4.0",
+    "ckbox": "^2.8.0",
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
     "vue": "^3.4.35"

--- a/real-time-collaboration-with-context/package.json
+++ b/real-time-collaboration-with-context/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "ckeditor5": "45.2.0",
     "ckeditor5-premium-features": "45.2.0",
-    "ckbox": "^2.4.0"
+    "ckbox": "^2.8.0"
   },
   "devDependencies": {
     "vite": "^5.3.5"


### PR DESCRIPTION
This PR updates React deps from v18 to v19 and pins CKBox dep to a more current version.

The update is needed since React v18 was causing issues with CKBox `2.8.0` in Next.js samples. Running `next build` was causing errors so it was not possible to build all Next.js-based samples.

```
Executed command: yarnpkg run build

$ next build
 ⚠ Disabling SWC Minifer will not be an option in the next major version. Please report any issues you may be experiencing to https://github.com/vercel/next.js/issues
  ▲ Next.js 14.2.26

   Creating an optimized production build ...
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[2]!/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[3]!/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css': No serializer registered for Warning
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> webpack/lib/ModuleWarning -> Warning
 ⚠ Compiled with warnings

../../node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[3]!../../node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css
Warning

(4599:3) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
../../node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css.webpack[javascript/auto]!=!./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[14].oneOf[12].use[3]!../../node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css
../../node_modules/ckeditor5-premium-features/dist/ckeditor5-premium-features.css
./components/ckeditor.js

 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/4) ...
TypeError: Cannot read properties of null (reading 'useRef')
    at exports.useRef (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/react/cjs/react.production.min.js:26:177)
    at eU (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/compiled/next-server/pages.runtime.prod.js:16:19757)
    at Wc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:253)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:481)

Error occurred prerendering page "/404". Read more: https://nextjs.org/docs/messages/prerender-error

TypeError: Cannot read properties of null (reading 'useRef')
    at exports.useRef (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/react/cjs/react.production.min.js:26:177)
    at eU (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/compiled/next-server/pages.runtime.prod.js:16:19757)
    at Wc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:253)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:481)
   Generating static pages (1/4)
TypeError: Cannot read properties of null (reading 'useRef')
    at exports.useRef (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/react/cjs/react.production.min.js:26:177)
    at eU (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/compiled/next-server/pages.runtime.prod.js:16:19757)
    at Wc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:253)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:481)

Error occurred prerendering page "/500". Read more: https://nextjs.org/docs/messages/prerender-error

TypeError: Cannot read properties of null (reading 'useRef')
    at exports.useRef (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/react/cjs/react.production.min.js:26:177)
    at eU (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/release-collaboration-samples/collaboration-for-next/node_modules/next/dist/compiled/next-server/pages.runtime.prod.js:16:19757)
    at Wc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:68:44)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:253)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:74:209)
    at Z (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:76:89)
    at Zc (/Users/mikolajsawicki/workspace/ckeditor5-e2e-tests-2/ckeditor5-collaboration-samples/build/node_modules/react-dom/cjs/react-dom-server.browser.production.min.js:70:481)
   Generating static pages (2/4)
   Generating static pages (3/4)
 ✓ Generating static pages (4/4)

> Export encountered errors on following paths:
	/_error: /404
	/_error: /500
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.


 4/16 │ COLLABORATION FOR NEXT                                            │ ❌ Building finished with an error.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```