### PR TITLE
Use node LTS (v22) docker image for all CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ commands:
 
 jobs:
   notify_ci_failure:
-    machine: true
+    docker:
+      - image: cimg/node:lts
     parameters:
       hideAuthor:
         type: string
@@ -40,7 +41,8 @@ jobs:
           no_output_timeout: 1h
 
   lint:
-    machine: true
+    docker:
+      - image: cimg/node:lts
     steps:
       - checkout
       - bootstrap_repository_command
@@ -56,7 +58,7 @@ jobs:
       - bootstrap_repository_command
       - run:
           name: Build local
-          command: yarn samples:build-local
+          command: yarn samples:build-local -c 1
 
   build:
     docker:
@@ -66,7 +68,7 @@ jobs:
       - bootstrap_repository_command
       - run:
           name: Build
-          command: yarn samples:build
+          command: yarn samples:build -c 1
 
 workflows:
   version: 2


### PR DESCRIPTION
To force the use of the latest node v22 LTS, since it started failing with older version:

- https://app.circleci.com/pipelines/github/ckeditor/ckeditor5-collaboration-samples/88/workflows/f44be44b-86f6-469d-83a1-59e5424b8d87/jobs/259
- https://app.circleci.com/pipelines/github/ckeditor/ckeditor5-collaboration-samples/88/workflows/f44be44b-86f6-469d-83a1-59e5424b8d87/jobs/257

I needed to limit concurrency by env var since using docker image reported 36 cores - so we ended up with 18 parallel jobs, which caused out of memory:

```
🛠️  Starting building 16 samples, 18 in parallel
```

Worth noting is that switching from `machine` to `docker` halves the available RAM (so we end up with 4GB instead of 8GB), but it's not a problem in this case.