### PR TITLE
Update `glob` to the latest version

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -7,7 +7,7 @@
 
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
-const glob = require( 'glob' );
+const { globSync } = require( 'glob' );
 const minimist = require( 'minimist' );
 const chalk = require( 'chalk' );
 const { installDependencies, runBuildCommand, getPathsToSampleSourceDirectories, toArray } = require( './utils' );
@@ -183,7 +183,7 @@ async function useNightlyVersions( ckeditor5path ) {
 
 	const samplePackageJsonPaths = packageJson.workspaces
 		.map( workspace => `${ DESTINATION_DIRECTORY }/${ workspace }` )
-		.flatMap( workspace => glob.sync( `${ workspace }/package.json` ) );
+		.flatMap( workspace => globSync( `${ workspace }/package.json` ) );
 
 	for ( const samplePackageJsonPath of samplePackageJsonPaths ) {
 		const samplePackageJson = await fs.readJson( samplePackageJsonPath );
@@ -224,7 +224,7 @@ function updateVersion( version, callback, dependencies ) {
 async function copySample( sample ) {
 	await fs.emptyDir( `${ RELEASE_DIRECTORY }/${ sample.name }` );
 
-	const filesToCopy = glob.sync( `${ sample.name }/**`, {
+	const filesToCopy = globSync( `${ sample.name }/**`, {
 		ignore: [
 			sample.name,
 			'**/node_modules/**',
@@ -314,7 +314,7 @@ async function keepBuildOnly( sample ) {
  * @returns {Boolean}
  */
 function areLocalPackagesAvailable( ckeditor5Path ) {
-	const pathsToLocalPackages = glob.sync( '{packages/*,external/*/packages/*}', {
+	const pathsToLocalPackages = globSync( '{packages/*,external/*/packages/*}', {
 		cwd: ckeditor5Path
 	} );
 

--- a/_scripts/utils.js
+++ b/_scripts/utils.js
@@ -11,7 +11,7 @@ const { spawn } = require( 'child_process' );
 const byline = require( 'byline' );
 const fs = require( 'fs-extra' );
 const chalk = require( 'chalk' );
-const glob = require( 'glob' );
+const { globSync } = require( 'glob' );
 
 module.exports = {
 	installDependencies,
@@ -139,7 +139,7 @@ function runCommandAsync( command, args, directoryPath, verbose = false, rejectO
  * @returns {Array.<String>}
  */
 function getPathsToSampleSourceDirectories( sampleNames = [] ) {
-	return glob.sync( join( '.', '*' ) )
+	return globSync( join( '.', '*' ) )
 		.filter( isSampleSourceDirectory )
 		.filter( sampleNames.length === 0 ? () => true : sample => sampleNames.includes( sample ) );
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chalk": "^4.1.2",
     "depcheck": "^1.4.7",
     "fs-extra": "^10.0.0",
-    "glob": "^7.2.0",
+    "glob": "^11.0.3",
     "minimist": "^1.2.5",
     "npm-check-updates": "^16.14.20"
   },


### PR DESCRIPTION
This PR aims to use the latest available in the registry, the `glob` package.

To verify if the proposed changes work as expected, I added two `console.log()`s to the changed files:

```diff
diff --git a/_scripts/build.js b/_scripts/build.js
index ec73425..d8ab0dc 100644
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -12,6 +12,8 @@ const minimist = require( 'minimist' );
 const chalk = require( 'chalk' );
 const { installDependencies, runBuildCommand, getPathsToSampleSourceDirectories, toArray } = require( './utils' );

+console.log( {globSync} );
+
 // The color palette used to display the names of the currently built samples to make it easier to distinguish them in the wall of the logs.
 // The number of colors is less than the total number of samples, so some samples will have the same color.
 const SAMPLE_COLORS = [ '#A297BF', '#DEABC6', '#ED8C78', '#E8C290', '#F7F4C9', '#A8E3B4', '#9FCCED' ];
diff --git a/_scripts/utils.js b/_scripts/utils.js
index 916c252..b6bd74c 100644
--- a/_scripts/utils.js
+++ b/_scripts/utils.js
@@ -13,6 +13,8 @@ const fs = require( 'fs-extra' );
 const chalk = require( 'chalk' );
 const { globSync } = require( 'glob' );

+console.log( {globSync} );
+
 module.exports = {
 	installDependencies,
 	runBuildCommand,
```

And then, executed `yarn samples:build`.

Results:

```
yarn run v1.22.22
$ node --max_old_space_size=4096 _scripts/build
{
  globSync: [Function: globSync] {
    stream: [Function: globStreamSync],
    iterate: [Function: globIterateSync]
  }
}
{
  globSync: [Function: globSync] {
    stream: [Function: globStreamSync],
    iterate: [Function: globIterateSync]
  }
}

🛠️  Starting building 16 samples, 6 in parallel

🧹 Removing the release directory…

📄 Copying samples…

🔗 Installing dependencies…
```