### PR TITLE
Update `npm-check-updates` to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "minimist": "^1.2.5",
-    "npm-check-updates": "^16.14.20"
+    "npm-check-updates": "^18.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-ci": "^44.0.0",


### PR DESCRIPTION
This PR aims to use the latest available in the registry, the `npm-check-updates` package.

To verify if the proposed changes work as expected, I executed the `yarn samples:update-dependencies` command.

Results:

```
$ node --max_old_space_size=4096 _scripts/update-dependencies
Updating dependencies for the "collaboration-comments-outside-of-editor" sample...

Executed command: npx ncu -u -e 2

Using yarn
Upgrading /Users/pomek/Projects/ckeditor/ckeditor5-collaboration-samples/collaboration-comments-outside-of-editor/package.json


 ckbox  ^2.8.0  →  ^2.8.2
 vite   ^5.3.5  →  ^7.1.5

Dependencies not up-to-date

...
```