### PR TITLE
Improve the dependencies update script

### DIFF
--- a/_scripts/check-dependencies.js
+++ b/_scripts/check-dependencies.js
@@ -23,7 +23,7 @@ main().catch( error => {
  */
 async function main() {
 	const options = parseArguments( process.argv.slice( 2 ) );
-	const pathsToSampleSourceDirectories = getPathsToSampleSourceDirectories( options.sampleNames );
+	const pathsToSampleSourceDirectories = getPathsToSampleSourceDirectories( options.sampleNames, true );
 
 	await checkDependencies( pathsToSampleSourceDirectories, options.verbose );
 }

--- a/_scripts/update-dependencies.js
+++ b/_scripts/update-dependencies.js
@@ -5,9 +5,19 @@
  * For licensing, see LICENSE.md.
  */
 
+const { promisify } = require( 'util' );
+const { exec } = require( 'child_process' );
+const { glob } = require( 'glob' );
+const fs = require( 'fs-extra' );
 const minimist = require( 'minimist' );
+const path = require( 'upath' );
 const chalk = require( 'chalk' );
 const { getPathsToSampleSourceDirectories, runCommand, runCommandAsync, toArray } = require( './utils' );
+
+const CDN_LINK_PATTERNS = [
+	/(https:\/\/cdn\.ckeditor\.com\/ckeditor5\/)([^/]+)(\/ckeditor5\.css)/g,
+	/(https:\/\/cdn\.ckeditor\.com\/ckeditor5-premium-features\/)([^/]+)(\/ckeditor5-premium-features\.css)/g
+];
 
 main().catch( error => {
 	if ( error ) {
@@ -35,11 +45,15 @@ async function main() {
 		return Promise.reject();
 	}
 
-	const pathsToSampleSourceDirectories = getPathsToSampleSourceDirectories( options.sampleNames );
+	const editorVersion = await getEditorVersionFromNpm( options.verbose );
+	const pathsToSampleSourceDirectories = getPathsToSampleSourceDirectories( options.sampleNames, true );
 
-	const numberOfChangedPackages = await updateDependencies( pathsToSampleSourceDirectories, options.ckeditorOnly, options.verbose );
-	if ( numberOfChangedPackages > 0 ) {
-		console.log( chalk.green( `✨ Updated ${ chalk.bold( numberOfChangedPackages ) } dependencies.` ) );
+	const numberOfDependencyChanges = await updateDependencies( pathsToSampleSourceDirectories, options.ckeditorOnly, options.verbose );
+	const numberOfCdnChanges = await updateCdnConfigurations( pathsToSampleSourceDirectories, editorVersion, options.verbose );
+	const numberOfChangedSamples = numberOfDependencyChanges + numberOfCdnChanges;
+
+	if ( numberOfChangedSamples > 0 ) {
+		console.log( chalk.green( `✨ Updated ${ chalk.bold( numberOfChangedSamples ) } samples.` ) );
 
 		if ( options.commit ) {
 			await commitChanges( options );
@@ -47,7 +61,7 @@ async function main() {
 			console.log( chalk.green( '✨ All changes are committed.' ) );
 		}
 	} else {
-		console.log( '✨ All packages are up to date.' );
+		console.log( '✨ All packages and CDN configurations are up to date.' );
 	}
 }
 
@@ -80,7 +94,7 @@ async function updateDependencies( pathsToSampleSourceDirectories, ckeditorOnly,
 	for ( const sample of pathsToSampleSourceDirectories ) {
 		console.log( `Updating dependencies for the "${ sample }" sample...` );
 
-		const params = [ 'dlx', 'npm-check-updates', '-u', '-e', 2 ];
+		const params = [ 'dlx', 'npm-check-updates', '-u', '-e', 2, '--dep', 'peer,dev,prod' ];
 
 		if ( ckeditorOnly ) {
 			params.push( '*ckeditor5*' );
@@ -93,9 +107,75 @@ async function updateDependencies( pathsToSampleSourceDirectories, ckeditorOnly,
 		}
 	}
 
-	await runCommandAsync( 'pnpm', [ 'install' ], process.cwd(), verbose, true );
+	await runCommandAsync( 'pnpm', [ 'install', '--lockfile-only' ], process.cwd(), verbose, true );
 
 	return updatedPackages;
+}
+
+/**
+ * Updates CKEditor 5 CDN configuration in samples.
+ *
+ * @param {Array.<String>} pathsToSampleSourceDirectories List of paths to the samples.
+ * @param {String} editorVersion CKEditor 5 version used in CDN links.
+ * @param {Boolean} verbose Prints more information.
+ * @returns {Promise.<Number>} Number of samples where CDN links were changed.
+ */
+async function updateCdnConfigurations( pathsToSampleSourceDirectories, editorVersion, verbose ) {
+	let numberOfCdnChanges = 0;
+
+	for ( const sample of pathsToSampleSourceDirectories ) {
+		console.log( `Updating CDN configuration for the "${ sample }" sample...` );
+
+		const globPattern = [ '*.js', '*.jsx', '*.ts', '*.tsx', '*.vue' ].map( fileType => path.join( sample, '**', fileType ) );
+		const filePaths = await glob( globPattern, {
+			ignore: [
+				path.join( sample, 'build', '**' ),
+				path.join( sample, 'node_modules', '**' )
+			]
+		} );
+
+		let sampleChanged = false;
+
+		for ( const filePath of filePaths ) {
+			const fileContent = await fs.readFile( filePath, 'utf8' );
+			let nextContent = fileContent;
+
+			for ( const regex of CDN_LINK_PATTERNS ) {
+				nextContent = nextContent.replace( regex, `$1${ editorVersion }$3` );
+			}
+
+			if ( nextContent !== fileContent ) {
+				await fs.writeFile( filePath, nextContent, 'utf8' );
+
+				sampleChanged = true;
+			}
+		}
+
+		if ( sampleChanged ) {
+			numberOfCdnChanges++;
+		}
+	}
+
+	return numberOfCdnChanges;
+}
+
+/**
+ * Retrieves CKEditor 5 version from npm registry.
+ *
+ * @param {Boolean} verbose Prints more information.
+ * @returns {Promise.<String>}
+ */
+async function getEditorVersionFromNpm( verbose ) {
+	const command = 'npm view ckeditor5 version --json';
+
+	if ( verbose ) {
+		console.log( `Running command: ${ command }` );
+	}
+
+	const execAsync = promisify( exec );
+	const { stdout } = await execAsync( command );
+
+	return JSON.parse( stdout.trim() );
 }
 
 /**

--- a/_scripts/utils.js
+++ b/_scripts/utils.js
@@ -136,11 +136,13 @@ function runCommandAsync( command, args, directoryPath, verbose = false, rejectO
  * Retrieves the paths to samples' source directories.
  *
  * @param {Array.<String>} [sampleNames] The optional sample name. If not provided, all samples are checked.
+ * @param {Boolean} [includeIntegrations=false] If set, includes the `integrations` sample directory.
  * @returns {Array.<String>}
  */
-function getPathsToSampleSourceDirectories( sampleNames = [] ) {
+function getPathsToSampleSourceDirectories( sampleNames = [], includeIntegrations = false ) {
 	return globSync( join( '.', '*' ) )
 		.filter( isSampleSourceDirectory )
+		.filter( sample => includeIntegrations || sample !== 'integrations' )
 		.filter( sampleNames.length === 0 ? () => true : sample => sampleNames.includes( sample ) );
 }
 
@@ -169,5 +171,5 @@ function isSampleSourceDirectory( path ) {
 	const pkg = readFileSync( join( path, 'package.json' ), 'utf8' );
 	const pkgData = JSON.parse( pkg );
 
-	return pkgData.name.startsWith( '@ckeditor/' );
+	return pkgData.name.startsWith( '@ckeditor/' ) || pkgData.name.startsWith( 'ckeditor5-' );
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "fs-extra": "^10.0.0",
     "glob": "^11.0.3",
     "minimist": "^1.2.5",
-    "npm-check-updates": "^18.0.0"
+    "npm-check-updates": "^19.3.2",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-bump-year": "^54.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,11 @@ importers:
         specifier: ^1.2.5
         version: 1.2.8
       npm-check-updates:
-        specifier: ^18.0.0
-        version: 18.3.1
+        specifier: ^19.3.2
+        version: 19.3.2
+      upath:
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@ckeditor/ckeditor5-dev-bump-year':
         specifier: ^54.0.0
@@ -5116,9 +5119,9 @@ packages:
     resolution: {integrity: sha512-IxaQZDMsqfQ2Lz37VvyyEtKLe8FsRZuysmedy/N06TU1RyVppYKXrO4xIhR0F+7ubIBox6Q7nir6fQI3ej39iA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  npm-check-updates@18.3.1:
-    resolution: {integrity: sha512-5HwKPq7ybOOA1xB4FZg/1ToZZ5/i93U8m3co1mb3GYZAZPDkcxEFukQTTp/Abym+ZY6ShfrHl45Y0rCcwsNnQA==}
-    engines: {node: ^18.18.0 || >=20.0.0, npm: '>=8.12.1'}
+  npm-check-updates@19.3.2:
+    resolution: {integrity: sha512-9rr3z7znFjCSuaFxHGTFR2ZBOvLWaJcpLKmIquoTbDBNrwAGiHhv4MZyty6EJ9Xo/aMn35+2ISPSMgWIXx5Xkg==}
+    engines: {node: '>=20.0.0', npm: '>=8.12.1'}
     hasBin: true
 
   npm-install-checks@7.1.2:
@@ -7694,8 +7697,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.5.0
       ckeditor5: 47.5.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-import-word@47.5.0':
     dependencies:
@@ -7733,8 +7734,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.5.0
       '@ckeditor/ckeditor5-utils': 47.5.0
       ckeditor5: 47.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-line-height@47.5.0':
     dependencies:
@@ -7759,8 +7758,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.5.0
       ckeditor5: 47.5.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-list-multi-level@47.5.0':
     dependencies:
@@ -7784,8 +7781,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.5.0
       '@ckeditor/ckeditor5-utils': 47.5.0
       ckeditor5: 47.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-markdown-gfm@47.5.0':
     dependencies:
@@ -7823,8 +7818,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.5.0
       '@ckeditor/ckeditor5-widget': 47.5.0
       ckeditor5: 47.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-mention@47.5.0':
     dependencies:
@@ -10458,8 +10451,6 @@ snapshots:
   ckeditor5-collaboration@47.5.0:
     dependencies:
       '@ckeditor/ckeditor5-collaboration-core': 47.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   ckeditor5-premium-features@47.5.0(ckeditor5@47.5.0):
     dependencies:
@@ -12600,7 +12591,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 4.0.0
 
-  npm-check-updates@18.3.1: {}
+  npm-check-updates@19.3.2: {}
 
   npm-install-checks@7.1.2:
     dependencies:


### PR DESCRIPTION
### Summary

- Update packages in all dependency-related sections in `package.json` in samples.
- Update CKEditor 5 version in CDN configuration in samples.

Closes https://github.com/ckeditor/ckeditor5-collaboration-samples/issues/84

### How to test it

1. Switch to `i/84` branch and run `pnpm install`.
2. Run update script used during release process: `pnpm run samples:update-dependencies --ckeditor-only`
   - It should bump `@ckeditor/ckeditor5-vue` to `7.3.1` in Vue samples: `collaboration-for-vue` and `real-time-collaboration-for-vue` and also regenerate the lock file.
3. `git restore .`.
4. Now let's check if bumping CKEditor 5 version from previous one to the current one works as expected. Find and replace all `47.5.0` with `47.4.0`.
5. Commit the changes (temporarily) since the script requires that working directory is clean.
6. Run `pnpm run samples:update-dependencies --ckeditor-only`.
   - Now it should bump all CKEditor 5 versions to `47.5.0` in all files, including CDN configurations.
7. Revert the last commmit: `git reset HEAD^`.
   - Now the working directory state should be the same as in point 2, so only the recently updated `@ckeditor/ckeditor5-vue` package stays. All other changes to bumping CKEditor 5 version are gone because they all are the same as in the recent release of collaboration samples. It means that all places required to be bumped were bumped by the script.
8. `git restore .` to clean up the mess.