### PR TITLE
Update ckbox to `v2.13.1`.

### DIFF
--- a/collaboration-comments-outside-of-editor/package.json
+++ b/collaboration-comments-outside-of-editor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0"

--- a/collaboration-editor-classic/package.json
+++ b/collaboration-editor-classic/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0"

--- a/collaboration-for-angular/package.json
+++ b/collaboration-for-angular/package.json
@@ -17,7 +17,7 @@
     "@angular/forms": "^20.3.27",
     "@angular/platform-browser": "^20.3.27",
     "@ckeditor/ckeditor5-angular": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0",

--- a/collaboration-for-next/package.json
+++ b/collaboration-for-next/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0",

--- a/collaboration-for-react/package.json
+++ b/collaboration-for-react/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0",

--- a/collaboration-for-vue/package.json
+++ b/collaboration-for-vue/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-vue": "8.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 4.1.2
       depcheck:
         specifier: ^1.4.7
-        version: 1.4.7(supports-color@7.2.0)
+        version: 1.4.7
       fs-extra:
         specifier: ^10.0.0
         version: 10.1.0
@@ -54,19 +54,19 @@ importers:
         version: 58.0.0
       '@eslint-react/eslint-plugin':
         specifier: ^5.17.3
-        version: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       eslint:
         specifier: ^10.0.0
-        version: 10.7.0(supports-color@7.2.0)
+        version: 10.7.0
       eslint-config-ckeditor5:
         specifier: ^19.0.0
-        version: 19.0.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 19.0.0(eslint@10.7.0)(typescript@5.9.3)
       eslint-plugin-ckeditor5-rules:
         specifier: ^19.0.0
         version: 19.0.0
       eslint-plugin-vue:
         specifier: ^10.1.0
-        version: 10.9.2(@stylistic/eslint-plugin@4.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0))
+        version: 10.9.2(@stylistic/eslint-plugin@4.4.1(eslint@10.7.0)(typescript@5.9.3))(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.1(eslint@10.7.0))
       globals:
         specifier: ^16.2.0
         version: 16.5.0
@@ -81,25 +81,25 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.49.0
-        version: 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 8.62.0(eslint@10.7.0)(typescript@5.9.3)
       vue-eslint-parser:
         specifier: ^10.1.3
-        version: 10.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 10.4.1(eslint@10.7.0)
 
   collaboration-comments-outside-of-editor:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -108,17 +108,17 @@ importers:
   collaboration-editor-classic:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -143,32 +143,32 @@ importers:
         version: 20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))
       '@ckeditor/ckeditor5-angular':
         specifier: 11.2.0
-        version: 11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0(supports-color@7.2.0))(rxjs@7.8.2)
+        version: 11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0)(rxjs@7.8.2)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       zone.js:
         specifier: ~0.15.1
         version: 0.15.1
     devDependencies:
       '@angular/build':
         specifier: ^20.3.27
-        version: 20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)
       '@angular/cli':
         specifier: ^20.3.27
-        version: 20.3.30(@types/node@26.1.2)(chokidar@4.0.3)(supports-color@7.2.0)
+        version: 20.3.30(@types/node@26.1.2)(chokidar@4.0.3)
       '@angular/compiler-cli':
         specifier: ^20.3.27
-        version: 20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3)
+        version: 20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -177,22 +177,22 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-react':
         specifier: 11.2.0
-        version: 11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       next:
         specifier: 16.3.3
-        version: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0)
+        version: 16.3.3(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -202,10 +202,10 @@ importers:
     devDependencies:
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5(supports-color@7.2.0)
+        version: 9.39.5
       eslint-config-next:
         specifier: 16.2.11
-        version: 16.2.11(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 16.2.11(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
       eslint-plugin-ckeditor5-rules:
         specifier: ^20.0.0
         version: 20.0.0
@@ -214,19 +214,19 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-react':
         specifier: 11.2.0
-        version: 11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       react:
         specifier: ^19
         version: 19.2.4
@@ -236,7 +236,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0)
@@ -245,19 +245,19 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-vue':
         specifier: 8.2.0
-        version: 8.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(vue@3.5.25(typescript@5.9.3))
+        version: 8.2.0(ckeditor5@48.4.0)(vue@3.5.25(typescript@5.9.3))
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       vue:
         specifier: ^3.4.35
         version: 3.5.25(typescript@5.9.3)
@@ -278,17 +278,17 @@ importers:
   real-time-collaboration-comments-outside-of-editor:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -297,14 +297,14 @@ importers:
   real-time-collaboration-editor-classic:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -313,14 +313,14 @@ importers:
   real-time-collaboration-editor-document:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -329,17 +329,17 @@ importers:
   real-time-collaboration-editor-headers-and-footers:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -348,17 +348,17 @@ importers:
   real-time-collaboration-editor-multi-root:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -368,19 +368,19 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-react':
         specifier: 11.2.0
-        version: 11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-collaboration-samples-integrations:
         specifier: workspace:*
         version: link:../integrations
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       react:
         specifier: ^19
         version: 19.2.4
@@ -390,7 +390,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0)
@@ -414,29 +414,29 @@ importers:
         version: 20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))
       '@ckeditor/ckeditor5-angular':
         specifier: 11.2.0
-        version: 11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0(supports-color@7.2.0))(rxjs@7.8.2)
+        version: 11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0)(rxjs@7.8.2)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       zone.js:
         specifier: ~0.15.1
         version: 0.15.1
     devDependencies:
       '@angular/build':
         specifier: ^20.3.27
-        version: 20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)
+        version: 20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)
       '@angular/cli':
         specifier: ^20.3.27
-        version: 20.3.30(@types/node@26.1.2)(chokidar@4.0.3)(supports-color@7.2.0)
+        version: 20.3.30(@types/node@26.1.2)(chokidar@4.0.3)
       '@angular/compiler-cli':
         specifier: ^20.3.27
-        version: 20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3)
+        version: 20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -445,19 +445,19 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-react':
         specifier: 11.2.0
-        version: 11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       next:
         specifier: 16.3.3
-        version: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0)
+        version: 16.3.3(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -467,10 +467,10 @@ importers:
     devDependencies:
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5(supports-color@7.2.0)
+        version: 9.39.5
       eslint-config-next:
         specifier: 16.2.11
-        version: 16.2.11(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 16.2.11(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
       eslint-plugin-ckeditor5-rules:
         specifier: ^20.0.0
         version: 20.0.0
@@ -479,16 +479,16 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-react':
         specifier: 11.2.0
-        version: 11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       react:
         specifier: ^19
         version: 19.2.4
@@ -498,7 +498,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.7.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0)
@@ -507,16 +507,16 @@ importers:
     dependencies:
       '@ckeditor/ckeditor5-vue':
         specifier: 8.2.0
-        version: 8.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(vue@3.5.25(typescript@5.9.3))
+        version: 8.2.0(ckeditor5@48.4.0)(vue@3.5.25(typescript@5.9.3))
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
       vue:
         specifier: ^3.4.35
         version: 3.5.25(typescript@5.9.3)
@@ -531,14 +531,14 @@ importers:
   real-time-collaboration-paragraph-like-classic-editor:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -547,14 +547,14 @@ importers:
   real-time-collaboration-paragraph-like-multiroot-editor:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -563,14 +563,14 @@ importers:
   real-time-collaboration-with-context:
     dependencies:
       ckbox:
-        specifier: 2.13.0
-        version: 2.13.0(@types/node@26.1.2)
+        specifier: 2.13.1
+        version: 2.13.1(@types/node@26.1.2)
       ckeditor5:
         specifier: 48.4.0
-        version: 48.4.0(supports-color@7.2.0)
+        version: 48.4.0
       ckeditor5-premium-features:
         specifier: 48.4.0
-        version: 48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 48.4.0(ckeditor5@48.4.0)
     devDependencies:
       vite:
         specifier: ^7.3.6
@@ -856,19 +856,19 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@ckbox/components@2.13.0':
-    resolution: {integrity: sha512-cpizAZmtVR+vttCRdWUVyavJN3hiQbNefj5ilRDeLhW2GeaR5b7cWscs7tQAQI8FJ+7oCOGW8uKQfGwdYhkSsg==}
+  '@ckbox/components@2.13.1':
+    resolution: {integrity: sha512-0CO9LOw9yiocUQg0PWe4nFSIGuucZ6H5T+6+2Pr2dOISb2KeR0eQ3aqvmOurkhIEUPU1d9OngRdBIxp6IUSDAQ==}
     peerDependencies:
       react: ^19
       react-dom: ^19
 
-  '@ckbox/core@2.13.0':
-    resolution: {integrity: sha512-ogonCakCNz+cUdJRYkDjBI9kUcrty1NGTgM+yp3EPl1yYe9sIVqm0dx5pXoijPd3KttqeJdcINiV+vD/l+31xg==}
+  '@ckbox/core@2.13.1':
+    resolution: {integrity: sha512-ZrStceHuk9+7Th3SGy7Ki6GY8rdGl+GZKg2FdjmlZAbXQkZrPBksJDG/dqbQ+P0ZkybgouBZggXwwBHXLnAQLQ==}
     peerDependencies:
       react: ^19
 
-  '@ckbox/i18n@2.13.0':
-    resolution: {integrity: sha512-8x8qhGAwmiARUmPym/96kQEXNsx4xaCKJAVVHEufB4myMIUesqFlzuxGlrAr/wU29UwogotU+wqgeE1pzX05iA==}
+  '@ckbox/i18n@2.13.1':
+    resolution: {integrity: sha512-amDQNkE+rPxNf0WJsNCKRYYwLFUiP0Nv3dV6n+KPUKl5RLizG//R8ly951/LxEw7kAJVG4JLU5SMN+tWM5w7JA==}
     peerDependencies:
       react: ^19
 
@@ -2595,11 +2595,11 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@tanstack/query-core@5.100.10':
-    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
+  '@tanstack/query-core@5.102.8':
+    resolution: {integrity: sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==}
 
-  '@tanstack/react-query@5.100.10':
-    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
+  '@tanstack/react-query@5.102.8':
+    resolution: {integrity: sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -2684,8 +2684,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -3248,8 +3248,8 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  ckbox@2.13.0:
-    resolution: {integrity: sha512-HzC/s7sLPjEZu8WJuoE/FVSpQXN19RjyM5DP4ERpXip41LJE9Dd0p9VvN/l49YfCpmFj5yomwsWPnJR7f/8Smg==}
+  ckbox@2.13.1:
+    resolution: {integrity: sha512-f0WN6L8CCxr05aPc9F9dXgRubXS8odQ9OQUhdqdLXdSfgCUYXYSWLj4Yj0MyE/kR3tnG46h6+13c+PGjy4Liwg==}
 
   ckeditor5-premium-features@48.4.0:
     resolution: {integrity: sha512-pd0/sscYFDN6WJ04ZtvPhN2a+75zsDfc+A5UBZOzxuk2F5fbXAAq22wiML06WLXJjZbTzcUqLuv6L24Fg4fM/Q==}
@@ -5177,10 +5177,10 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.8
 
   react-focus-lock@2.13.7:
     resolution: {integrity: sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==}
@@ -5191,8 +5191,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-hook-form@7.75.0:
-    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
+  react-hook-form@7.87.0:
+    resolution: {integrity: sha512-zhFzWvLxNHH+8839OnZcUxgMZw88ah2jZWDWvKWgF3Tpbnd0vKL+dlcuU3nZVWESZQjd81EW8K+wU+cYfYAc0w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -5244,8 +5244,8 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
@@ -6211,13 +6211,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/build@20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(supports-color@7.2.0)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)':
+  '@angular/build@20.3.30(@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3))(@angular/compiler@20.3.29)(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@26.1.2)(chokidar@4.0.3)(postcss@8.5.23)(tslib@2.8.1)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.30(chokidar@4.0.3)
       '@angular/compiler': 20.3.29
-      '@angular/compiler-cli': 20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3)
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@angular/compiler-cli': 20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.14(@types/node@26.1.2)
@@ -6225,8 +6225,8 @@ snapshots:
       beasties: 0.3.5
       browserslist: 4.28.8
       esbuild: 0.28.1
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      istanbul-lib-instrument: 6.0.3(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       listr2: 9.0.1
       magic-string: 0.30.17
@@ -6261,14 +6261,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/cli@20.3.30(@types/node@26.1.2)(chokidar@4.0.3)(supports-color@7.2.0)':
+  '@angular/cli@20.3.30(@types/node@26.1.2)(chokidar@4.0.3)':
     dependencies:
       '@angular-devkit/architect': 0.2003.30(chokidar@4.0.3)
       '@angular-devkit/core': 20.3.30(chokidar@4.0.3)
       '@angular-devkit/schematics': 20.3.30(chokidar@4.0.3)
       '@inquirer/prompts': 7.8.2(@types/node@26.1.2)
       '@listr2/prompt-adapter-inquirer': 3.0.1(@inquirer/prompts@7.8.2(@types/node@26.1.2))(@types/node@26.1.2)(listr2@9.0.1)
-      '@modelcontextprotocol/sdk': 1.30.0(supports-color@7.2.0)(zod@4.1.13)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.1.13)
       '@schematics/angular': 20.3.30(chokidar@4.0.3)
       '@yarnpkg/lockfile': 1.1.0
       algoliasearch: 5.35.0
@@ -6276,7 +6276,7 @@ snapshots:
       jsonc-parser: 3.3.1
       listr2: 9.0.1
       npm-package-arg: 13.0.0
-      pacote: 21.5.1(supports-color@7.2.0)
+      pacote: 21.5.1
       resolve: 1.22.10
       semver: 7.7.2
       yargs: 18.0.0
@@ -6293,10 +6293,10 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(supports-color@7.2.0)(typescript@5.9.3)':
+  '@angular/compiler-cli@20.3.29(@angular/compiler@20.3.29)(typescript@5.9.3)':
     dependencies:
       '@angular/compiler': 20.3.29
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@jridgewell/sourcemap-codec': 1.5.5
       chokidar: 4.0.3
       convert-source-map: 1.9.0
@@ -6343,20 +6343,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@7.2.0)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6385,19 +6385,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6422,14 +6422,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
@@ -6440,7 +6440,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@7.2.0)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -6448,7 +6448,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6457,38 +6457,38 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@ckbox/components@2.13.0(@types/node@26.1.2)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@ckbox/components@2.13.1(@types/node@26.1.2)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.18)
       blurhash: 2.0.5
       cropperjs: 1.6.2
       dnd-core: 16.0.1
       lodash: 4.18.1
       pdfjs-dist: 4.10.38
-      react: 19.2.6
-      react-dnd: 16.0.1(@types/node@26.1.2)(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.8
+      react-dnd: 16.0.1(@types/node@26.1.2)(@types/react@19.2.18)(react@19.2.8)
       react-dnd-html5-backend: 16.0.1
-      react-dom: 19.2.6(react@19.2.6)
-      react-focus-lock: 2.13.7(@types/react@19.2.14)(react@19.2.6)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
-      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-dom: 19.2.8(react@19.2.8)
+      react-focus-lock: 2.13.7(@types/react@19.2.18)(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
+      react-transition-group: 4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
 
-  '@ckbox/core@2.13.0(@types/node@26.1.2)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@ckbox/core@2.13.1(@types/node@26.1.2)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@ckbox/components': 2.13.0(@types/node@26.1.2)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@ckbox/i18n': 2.13.0(react@19.2.6)
-      '@tanstack/react-query': 5.100.10(react@19.2.6)
+      '@ckbox/components': 2.13.1(@types/node@26.1.2)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@ckbox/i18n': 2.13.1(react@19.2.8)
+      '@tanstack/react-query': 5.102.8(react@19.2.8)
       crypto-js: 4.2.0
       lodash: 4.18.1
       nanoid: 5.1.16
-      react: 19.2.6
-      react-hook-form: 7.75.0(react@19.2.6)
+      react: 19.2.8
+      react-hook-form: 7.87.0(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/hoist-non-react-statics'
@@ -6496,18 +6496,18 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  '@ckbox/i18n@2.13.0(react@19.2.6)':
+  '@ckbox/i18n@2.13.1(react@19.2.8)':
     dependencies:
-      react: 19.2.6
+      react: 19.2.8
       sprintf-js: 1.1.3
       tslib: 2.8.1
 
-  '@ckeditor/ckeditor-cloud-services-collaboration@54.2.7(@ckeditor/ckeditor5-utils@48.4.0)(supports-color@7.2.0)':
+  '@ckeditor/ckeditor-cloud-services-collaboration@54.2.7(@ckeditor/ckeditor5-utils@48.4.0)':
     dependencies:
       '@ckeditor/ckeditor5-utils': 48.4.0
       protobufjs: 7.6.5
-      socket.io-client: 4.8.3(supports-color@7.2.0)
-      socket.io-parser: 4.2.7(supports-color@7.2.0)
+      socket.io-client: 4.8.3
+      socket.io-parser: 4.2.7
       url-parse: 1.5.10
       uuid: 14.0.1
     transitivePeerDependencies:
@@ -6521,7 +6521,7 @@ snapshots:
       '@ckeditor/ckeditor5-upload': 48.4.0
       '@ckeditor/ckeditor5-utils': 48.4.0
 
-  '@ckeditor/ckeditor5-ai@48.4.0(supports-color@7.2.0)':
+  '@ckeditor/ckeditor5-ai@48.4.0':
     dependencies:
       '@ckeditor/ckeditor5-alignment': 48.4.0
       '@ckeditor/ckeditor5-clipboard': 48.4.0
@@ -6542,11 +6542,11 @@ snapshots:
       '@ckeditor/ckeditor5-link': 48.4.0
       '@ckeditor/ckeditor5-list': 48.4.0
       '@ckeditor/ckeditor5-list-multi-level': 48.4.0
-      '@ckeditor/ckeditor5-markdown-gfm': 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-markdown-gfm': 48.4.0
       '@ckeditor/ckeditor5-media-embed': 48.4.0
       '@ckeditor/ckeditor5-mention': 48.4.0
       '@ckeditor/ckeditor5-merge-fields': 48.4.0
-      '@ckeditor/ckeditor5-real-time-collaboration': 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-real-time-collaboration': 48.4.0
       '@ckeditor/ckeditor5-style': 48.4.0
       '@ckeditor/ckeditor5-table': 48.4.0
       '@ckeditor/ckeditor5-ui': 48.4.0
@@ -6573,13 +6573,13 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 48.4.0
       '@ckeditor/ckeditor5-utils': 48.4.0
 
-  '@ckeditor/ckeditor5-angular@11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0(supports-color@7.2.0))(rxjs@7.8.2)':
+  '@ckeditor/ckeditor5-angular@11.2.0(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/forms@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2))(ckeditor5@48.4.0)(rxjs@7.8.2)':
     dependencies:
       '@angular/common': 20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@angular/core': 20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/forms': 20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.29(@angular/common@20.3.29(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.29(@angular/compiler@20.3.29)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0(supports-color@7.2.0))
-      ckeditor5: 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0)
+      ckeditor5: 48.4.0
       rxjs: 7.8.2
       tslib: 2.8.1
 
@@ -6997,9 +6997,9 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 48.4.0
       '@ckeditor/ckeditor5-utils': 48.4.0
 
-  '@ckeditor/ckeditor5-integrations-common@2.4.1(ckeditor5@48.4.0(supports-color@7.2.0))':
+  '@ckeditor/ckeditor5-integrations-common@2.4.1(ckeditor5@48.4.0)':
     dependencies:
-      ckeditor5: 48.4.0(supports-color@7.2.0)
+      ckeditor5: 48.4.0
 
   '@ckeditor/ckeditor5-language@48.4.0':
     dependencies:
@@ -7070,29 +7070,6 @@ snapshots:
       remark-breaks: 4.0.0
       remark-gfm: 4.0.1
       remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-stringify: 11.0.0
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ckeditor/ckeditor5-markdown-gfm@48.4.0(supports-color@7.2.0)':
-    dependencies:
-      '@ckeditor/ckeditor5-clipboard': 48.4.0
-      '@ckeditor/ckeditor5-core': 48.4.0
-      '@ckeditor/ckeditor5-engine': 48.4.0
-      '@types/hast': 3.0.4
-      hast-util-from-dom: 5.0.1
-      hast-util-to-html: 9.0.5
-      hast-util-to-mdast: 10.1.2
-      hastscript: 9.0.1
-      rehype-dom-parse: 5.0.2
-      rehype-dom-stringify: 4.0.2
-      rehype-remark: 10.0.1
-      remark-breaks: 4.0.0
-      remark-gfm: 4.0.1(supports-color@7.2.0)
-      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
       remark-stringify: 11.0.0
       unified: 11.0.5
@@ -7187,15 +7164,15 @@ snapshots:
       '@ckeditor/ckeditor5-engine': 48.4.0
       '@ckeditor/ckeditor5-utils': 48.4.0
 
-  '@ckeditor/ckeditor5-react@11.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(react@19.2.4)':
+  '@ckeditor/ckeditor5-react@11.2.0(ckeditor5@48.4.0)(react@19.2.4)':
     dependencies:
-      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0(supports-color@7.2.0))
-      ckeditor5: 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0)
+      ckeditor5: 48.4.0
       react: 19.2.4
 
-  '@ckeditor/ckeditor5-real-time-collaboration@48.4.0(supports-color@7.2.0)':
+  '@ckeditor/ckeditor5-real-time-collaboration@48.4.0':
     dependencies:
-      '@ckeditor/ckeditor-cloud-services-collaboration': 54.2.7(@ckeditor/ckeditor5-utils@48.4.0)(supports-color@7.2.0)
+      '@ckeditor/ckeditor-cloud-services-collaboration': 54.2.7(@ckeditor/ckeditor5-utils@48.4.0)
       '@ckeditor/ckeditor5-cloud-services': 48.4.0
       '@ckeditor/ckeditor5-collaboration-core': 48.4.0
       '@ckeditor/ckeditor5-comments': 48.4.0
@@ -7418,10 +7395,10 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 48.4.0
       es-toolkit: 1.45.1
 
-  '@ckeditor/ckeditor5-vue@8.2.0(ckeditor5@48.4.0(supports-color@7.2.0))(vue@3.5.25(typescript@5.9.3))':
+  '@ckeditor/ckeditor5-vue@8.2.0(ckeditor5@48.4.0)(vue@3.5.25(typescript@5.9.3))':
     dependencies:
-      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0(supports-color@7.2.0))
-      ckeditor5: 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0)
+      ckeditor5: 48.4.0
       lodash-es: 4.18.1
       vue: 3.5.25(typescript@5.9.3)
 
@@ -7640,116 +7617,116 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
     dependencies:
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5)':
     dependencies:
-      eslint: 9.39.5(supports-color@7.2.0)
+      eslint: 9.39.5
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-react/ast@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/ast@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       string-ts: 2.3.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/core@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint-plugin@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/eslint-plugin@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
-      eslint-plugin-react-dom: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint-plugin-react-jsx: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint-plugin-react-naming-convention: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint-plugin-react-rsc: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint-plugin-react-web-api: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint-plugin-react-x: 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
+      eslint-plugin-react-dom: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint-plugin-react-jsx: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint-plugin-react-naming-convention: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint-plugin-react-rsc: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint-plugin-react-web-api: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      eslint-plugin-react-x: 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/eslint@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/jsx@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/jsx@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/shared@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/shared@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
       zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@eslint-react/var@5.17.3(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-array@0.21.2(supports-color@7.2.0)':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -7789,10 +7766,10 @@ snapshots:
       '@eslint/css-tree': 4.0.5
       '@eslint/plugin-kit': 0.7.2
 
-  '@eslint/eslintrc@3.3.6(supports-color@7.2.0)':
+  '@eslint/eslintrc@3.3.6':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -7803,20 +7780,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@10.7.0(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.7.0)':
     optionalDependencies:
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
 
   '@eslint/js@9.39.5': {}
 
-  '@eslint/markdown@6.6.0(supports-color@7.2.0)':
+  '@eslint/markdown@6.6.0':
     dependencies:
       '@eslint/core': 0.14.0
       '@eslint/plugin-kit': 0.3.5
       github-slugger: 2.0.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-      mdast-util-frontmatter: 2.0.1(supports-color@7.2.0)
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-frontmatter: 2.0.1
+      mdast-util-gfm: 3.1.0
       micromark-extension-frontmatter: 2.0.0
       micromark-extension-gfm: 3.0.0
     transitivePeerDependencies:
@@ -8203,7 +8180,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.1.13)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.13.4)
       ajv: 8.18.0
@@ -8213,8 +8190,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.2
-      express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.5.2(express@5.2.1(supports-color@7.2.0))
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.13.4
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -8414,13 +8391,13 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@npmcli/agent@4.0.2(supports-color@7.2.0)':
+  '@npmcli/agent@4.0.2':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 11.3.5
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8654,21 +8631,21 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.1': {}
 
-  '@sigstore/sign@4.1.1(supports-color@7.2.0)':
+  '@sigstore/sign@4.1.1':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
-      make-fetch-happen: 15.0.6(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6
       proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.2(supports-color@7.2.0)':
+  '@sigstore/tuf@4.0.2':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.1
-      tuf-js: 4.1.0(supports-color@7.2.0)
+      tuf-js: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8680,10 +8657,10 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@stylistic/eslint-plugin@4.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@stylistic/eslint-plugin@4.4.1(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -8696,12 +8673,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/query-core@5.100.10': {}
+  '@tanstack/query-core@5.102.8': {}
 
-  '@tanstack/react-query@5.100.10(react@19.2.6)':
+  '@tanstack/react-query@5.102.8(react@19.2.8)':
     dependencies:
-      '@tanstack/query-core': 5.100.10
-      react: 19.2.6
+      '@tanstack/query-core': 5.102.8
+      react: 19.2.8
 
   '@tufjs/canonical-json@2.0.0': {}
 
@@ -8780,15 +8757,15 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
+  '@types/react-transition-group@4.4.12(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  '@types/react@19.2.14':
+  '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
 
@@ -8796,15 +8773,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/type-utils': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.0
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -8812,15 +8789,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/type-utils': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.0
-      eslint: 9.39.5(supports-color@7.2.0)
+      eslint: 9.39.5
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -8828,44 +8805,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.7.0(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.0(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 9.39.5(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 9.39.5
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.62.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8888,37 +8865,37 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.0(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.7.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.0(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 9.39.5(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.5
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.7.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8930,13 +8907,13 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.62.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.62.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.62.0(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.62.0
       '@typescript-eslint/visitor-keys': 8.62.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.16
@@ -8945,13 +8922,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.64.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.16
@@ -8960,35 +8937,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.0(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.0(eslint@9.39.5)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.5(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      eslint: 9.39.5
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.64.0(eslint@10.7.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9104,11 +9081,11 @@ snapshots:
     dependencies:
       vite: 7.3.5(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0)
 
-  '@vitejs/plugin-react@4.7.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(@types/node@26.1.2)(sass@1.90.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -9387,11 +9364,11 @@ snapshots:
 
   blurhash@2.0.5: {}
 
-  body-parser@2.3.0(supports-color@7.2.0):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -9495,21 +9472,21 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  ckbox@2.13.0(@types/node@26.1.2):
+  ckbox@2.13.1(@types/node@26.1.2):
     dependencies:
-      '@ckbox/core': 2.13.0(@types/node@26.1.2)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
+      '@ckbox/core': 2.13.1(@types/node@26.1.2)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.3(@types/react@19.2.18)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/hoist-non-react-statics'
       - '@types/node'
 
-  ckeditor5-premium-features@48.4.0(ckeditor5@48.4.0(supports-color@7.2.0))(supports-color@7.2.0):
+  ckeditor5-premium-features@48.4.0(ckeditor5@48.4.0):
     dependencies:
-      '@ckeditor/ckeditor5-ai': 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-ai': 48.4.0
       '@ckeditor/ckeditor5-case-change': 48.4.0
       '@ckeditor/ckeditor5-collaboration-core': 48.4.0
       '@ckeditor/ckeditor5-comments': 48.4.0
@@ -9526,7 +9503,7 @@ snapshots:
       '@ckeditor/ckeditor5-merge-fields': 48.4.0
       '@ckeditor/ckeditor5-pagination': 48.4.0
       '@ckeditor/ckeditor5-paste-from-office-enhanced': 48.4.0
-      '@ckeditor/ckeditor5-real-time-collaboration': 48.4.0(supports-color@7.2.0)
+      '@ckeditor/ckeditor5-real-time-collaboration': 48.4.0
       '@ckeditor/ckeditor5-revision-history': 48.4.0
       '@ckeditor/ckeditor5-slash-command': 48.4.0
       '@ckeditor/ckeditor5-source-editing-enhanced': 48.4.0
@@ -9534,7 +9511,7 @@ snapshots:
       '@ckeditor/ckeditor5-track-changes': 48.4.0
       '@ckeditor/ckeditor5-uploadcare': 48.4.0
       '@ckeditor/ckeditor5-utils': 48.4.0
-      ckeditor5: 48.4.0(supports-color@7.2.0)
+      ckeditor5: 48.4.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9580,71 +9557,6 @@ snapshots:
       '@ckeditor/ckeditor5-link': 48.4.0
       '@ckeditor/ckeditor5-list': 48.4.0
       '@ckeditor/ckeditor5-markdown-gfm': 48.4.0
-      '@ckeditor/ckeditor5-media-embed': 48.4.0
-      '@ckeditor/ckeditor5-mention': 48.4.0
-      '@ckeditor/ckeditor5-minimap': 48.4.0
-      '@ckeditor/ckeditor5-page-break': 48.4.0
-      '@ckeditor/ckeditor5-paragraph': 48.4.0
-      '@ckeditor/ckeditor5-paste-from-office': 48.4.0
-      '@ckeditor/ckeditor5-remove-format': 48.4.0
-      '@ckeditor/ckeditor5-restricted-editing': 48.4.0
-      '@ckeditor/ckeditor5-select-all': 48.4.0
-      '@ckeditor/ckeditor5-show-blocks': 48.4.0
-      '@ckeditor/ckeditor5-source-editing': 48.4.0
-      '@ckeditor/ckeditor5-special-characters': 48.4.0
-      '@ckeditor/ckeditor5-style': 48.4.0
-      '@ckeditor/ckeditor5-table': 48.4.0
-      '@ckeditor/ckeditor5-typing': 48.4.0
-      '@ckeditor/ckeditor5-ui': 48.4.0
-      '@ckeditor/ckeditor5-undo': 48.4.0
-      '@ckeditor/ckeditor5-upload': 48.4.0
-      '@ckeditor/ckeditor5-utils': 48.4.0
-      '@ckeditor/ckeditor5-watchdog': 48.4.0
-      '@ckeditor/ckeditor5-widget': 48.4.0
-      '@ckeditor/ckeditor5-word-count': 48.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ckeditor5@48.4.0(supports-color@7.2.0):
-    dependencies:
-      '@ckeditor/ckeditor5-adapter-ckfinder': 48.4.0
-      '@ckeditor/ckeditor5-alignment': 48.4.0
-      '@ckeditor/ckeditor5-autoformat': 48.4.0
-      '@ckeditor/ckeditor5-autosave': 48.4.0
-      '@ckeditor/ckeditor5-basic-styles': 48.4.0
-      '@ckeditor/ckeditor5-block-quote': 48.4.0
-      '@ckeditor/ckeditor5-bookmark': 48.4.0
-      '@ckeditor/ckeditor5-ckbox': 48.4.0
-      '@ckeditor/ckeditor5-ckfinder': 48.4.0
-      '@ckeditor/ckeditor5-clipboard': 48.4.0
-      '@ckeditor/ckeditor5-cloud-services': 48.4.0
-      '@ckeditor/ckeditor5-code-block': 48.4.0
-      '@ckeditor/ckeditor5-core': 48.4.0
-      '@ckeditor/ckeditor5-easy-image': 48.4.0
-      '@ckeditor/ckeditor5-editor-balloon': 48.4.0
-      '@ckeditor/ckeditor5-editor-classic': 48.4.0
-      '@ckeditor/ckeditor5-editor-decoupled': 48.4.0
-      '@ckeditor/ckeditor5-editor-inline': 48.4.0
-      '@ckeditor/ckeditor5-editor-multi-root': 48.4.0
-      '@ckeditor/ckeditor5-emoji': 48.4.0
-      '@ckeditor/ckeditor5-engine': 48.4.0
-      '@ckeditor/ckeditor5-enter': 48.4.0
-      '@ckeditor/ckeditor5-essentials': 48.4.0
-      '@ckeditor/ckeditor5-find-and-replace': 48.4.0
-      '@ckeditor/ckeditor5-font': 48.4.0
-      '@ckeditor/ckeditor5-fullscreen': 48.4.0
-      '@ckeditor/ckeditor5-heading': 48.4.0
-      '@ckeditor/ckeditor5-highlight': 48.4.0
-      '@ckeditor/ckeditor5-horizontal-line': 48.4.0
-      '@ckeditor/ckeditor5-html-embed': 48.4.0
-      '@ckeditor/ckeditor5-html-support': 48.4.0
-      '@ckeditor/ckeditor5-icons': 48.4.0
-      '@ckeditor/ckeditor5-image': 48.4.0
-      '@ckeditor/ckeditor5-indent': 48.4.0
-      '@ckeditor/ckeditor5-language': 48.4.0
-      '@ckeditor/ckeditor5-link': 48.4.0
-      '@ckeditor/ckeditor5-list': 48.4.0
-      '@ckeditor/ckeditor5-markdown-gfm': 48.4.0(supports-color@7.2.0)
       '@ckeditor/ckeditor5-media-embed': 48.4.0
       '@ckeditor/ckeditor5-mention': 48.4.0
       '@ckeditor/ckeditor5-minimap': 48.4.0
@@ -9807,17 +9719,13 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@3.2.7(supports-color@7.2.0):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -9839,15 +9747,15 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depcheck@1.4.7(supports-color@7.2.0):
+  depcheck@1.4.7:
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.7
       '@vue/compiler-sfc': 3.5.33
       callsite: 1.0.0
       camelcase: 6.3.0
       cosmiconfig: 7.1.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       deps-regex: 0.2.0
       findup-sync: 5.0.0
       ignore: 5.3.2
@@ -9940,10 +9848,10 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  engine.io-client@6.6.6(supports-color@7.2.0):
+  engine.io-client@6.6.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       engine.io-parser: 5.2.3
       ws: 8.21.1
       xmlhttprequest-ssl: 2.1.2
@@ -10115,33 +10023,33 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-ckeditor5@19.0.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-config-ckeditor5@19.0.0(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
       '@eslint/css': 1.4.0
-      '@eslint/js': 10.0.1(eslint@10.7.0(supports-color@7.2.0))
-      '@eslint/markdown': 6.6.0(supports-color@7.2.0)
-      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@eslint/js': 10.0.1(eslint@10.7.0)
+      '@eslint/markdown': 6.6.0
+      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       eslint-plugin-ckeditor5-rules: 19.0.0
-      eslint-plugin-mocha: 11.2.0(eslint@10.7.0(supports-color@7.2.0))
+      eslint-plugin-mocha: 11.2.0(eslint@10.7.0)
       globals: 16.5.0
       typescript: 5.9.3
-      typescript-eslint: 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      typescript-eslint: 8.62.0(eslint@10.7.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-config-next@16.2.11(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-config-next@16.2.11(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.11
-      eslint: 9.39.5(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(supports-color@7.2.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.5(supports-color@7.2.0))
-      eslint-plugin-react-hooks: 7.1.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint: 9.39.5
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
+      eslint-plugin-react: 7.37.5(eslint@9.39.5)
+      eslint-plugin-react-hooks: 7.1.0(eslint@9.39.5)
       globals: 16.4.0
-      typescript-eslint: 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      typescript-eslint: 8.62.0(eslint@9.39.5)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10150,37 +10058,37 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-import-resolver-node@0.3.9(supports-color@7.2.0):
+  eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 9.39.5(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 9.39.5
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.5(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 9.39.5
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -10204,18 +10112,18 @@ snapshots:
       validate-npm-package-name: 6.0.2
       yaml: 2.9.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7(supports-color@7.2.0)
+      debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.5(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.9(supports-color@7.2.0)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint: 9.39.5
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
       hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10227,13 +10135,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5(supports-color@7.2.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -10243,7 +10151,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.5(supports-color@7.2.0)
+      eslint: 9.39.5
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -10252,110 +10160,110 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-mocha@11.2.0(eslint@10.7.0(supports-color@7.2.0)):
+  eslint-plugin-mocha@11.2.0(eslint@10.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(supports-color@7.2.0))
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      eslint: 10.7.0
       globals: 15.15.0
 
-  eslint-plugin-react-dom@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-dom@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
       compare-versions: 6.1.1
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.1.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-react-hooks@7.1.0(eslint@9.39.5):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      eslint: 9.39.5(supports-color@7.2.0)
+      eslint: 9.39.5
       hermes-parser: 0.25.1
       zod: 4.3.6
       zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-jsx@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-jsx@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-naming-convention@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-rsc@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-rsc@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-web-api@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
       birecord: 0.1.2
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
       ts-pattern: 5.9.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  eslint-plugin-react-x@5.17.3(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@eslint-react/ast': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/core': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/eslint': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/jsx': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/shared': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@eslint-react/var': 5.17.3(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@eslint-react/ast': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/core': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/eslint': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/jsx': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/shared': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
+      '@eslint-react/var': 5.17.3(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.7.0)(typescript@5.9.3)
       compare-versions: 6.1.1
-      eslint: 10.7.0(supports-color@7.2.0)
+      eslint: 10.7.0
       string-ts: 2.3.1
       ts-api-utils: 2.5.0(typescript@5.9.3)
       ts-pattern: 5.9.0
@@ -10363,7 +10271,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.5(supports-color@7.2.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.5):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -10371,7 +10279,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.5(supports-color@7.2.0)
+      eslint: 9.39.5
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -10385,19 +10293,19 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@4.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)):
+  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@4.4.1(eslint@10.7.0)(typescript@5.9.3))(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(vue-eslint-parser@10.4.1(eslint@10.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(supports-color@7.2.0))
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      eslint: 10.7.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)
+      vue-eslint-parser: 10.4.1(eslint@10.7.0)
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@stylistic/eslint-plugin': 4.4.1(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -10417,11 +10325,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.7.0(supports-color@7.2.0):
+  eslint@10.7.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -10431,7 +10339,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -10452,14 +10360,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.39.5(supports-color@7.2.0):
+  eslint@9.39.5:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@7.2.0)
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6(supports-color@7.2.0)
+      '@eslint/eslintrc': 3.3.6
       '@eslint/js': 9.39.5
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -10469,7 +10377,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -10533,25 +10441,25 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.5.2(express@5.2.1(supports-color@7.2.0)):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@7.2.0)
+      express: 5.2.1
       ip-address: 10.5.0
 
-  express@5.2.1(supports-color@7.2.0):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@7.2.0)
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10562,9 +10470,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@7.2.0)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -10609,9 +10517,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -10956,17 +10864,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11153,9 +11061,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@6.0.3(supports-color@7.2.0):
+  istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -11351,10 +11259,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-fetch-happen@15.0.6(supports-color@7.2.0):
+  make-fetch-happen@15.0.6:
     dependencies:
       '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
+      '@npmcli/agent': 4.0.2
       '@npmcli/redact': 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
@@ -11396,29 +11304,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      decode-named-character-reference: 1.3.0
-      devlop: 1.1.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-decode-string: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-      unist-util-stringify-position: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-frontmatter@2.0.1(supports-color@7.2.0):
+  mdast-util-frontmatter@2.0.1:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -11442,28 +11333,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-      mdast-util-to-markdown: 2.1.2
-      micromark-util-normalize-identifier: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11478,30 +11351,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11514,18 +11368,6 @@ snapshots:
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
-    dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-      mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11755,29 +11597,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
-      decode-named-character-reference: 1.3.0
-      devlop: 1.1.0
-      micromark-core-commonmark: 2.0.3
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-combine-extensions: 2.0.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-encode: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromark-util-subtokenize: 2.1.0
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  micromark@4.0.2(supports-color@7.2.0):
-    dependencies:
-      '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -11908,7 +11728,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0):
+  next@16.3.3(@types/node@26.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.90.0):
     dependencies:
       '@next/env': 16.3.3
       '@swc/helpers': 0.5.23
@@ -11917,7 +11737,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.3
       '@next/swc-darwin-x64': 16.3.3
@@ -12000,11 +11820,11 @@ snapshots:
       npm-package-arg: 13.0.0
       semver: 7.8.5
 
-  npm-registry-fetch@19.1.1(supports-color@7.2.0):
+  npm-registry-fetch@19.1.1:
     dependencies:
       '@npmcli/redact': 4.0.0
       jsonparse: 1.3.1
-      make-fetch-happen: 15.0.6(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6
       minipass: 7.1.3
       minipass-fetch: 5.0.2
       minizlib: 3.1.0
@@ -12113,7 +11933,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  pacote@21.5.1(supports-color@7.2.0):
+  pacote@21.5.1:
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 7.0.2
@@ -12127,9 +11947,9 @@ snapshots:
       npm-package-arg: 13.0.0
       npm-packlist: 10.0.4
       npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.1(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.1
       proc-log: 6.1.0
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 13.0.1
       tar: 7.5.22
     transitivePeerDependencies:
@@ -12267,96 +12087,96 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-clientside-effect@1.2.8(react@19.2.6):
+  react-clientside-effect@1.2.8(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.28.4
-      react: 19.2.6
+      react: 19.2.8
 
   react-dnd-html5-backend@16.0.1:
     dependencies:
       dnd-core: 16.0.1
 
-  react-dnd@16.0.1(@types/node@26.1.2)(@types/react@19.2.14)(react@19.2.6):
+  react-dnd@16.0.1(@types/node@26.1.2)(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
       dnd-core: 16.0.1
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
-      react: 19.2.6
+      react: 19.2.8
     optionalDependencies:
       '@types/node': 26.1.2
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-dom@19.2.6(react@19.2.6):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.6
+      react: 19.2.8
       scheduler: 0.27.0
 
-  react-focus-lock@2.13.7(@types/react@19.2.14)(react@19.2.6):
+  react-focus-lock@2.13.7(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.28.4
       focus-lock: 1.3.6
       prop-types: 15.8.1
-      react: 19.2.6
-      react-clientside-effect: 1.2.8(react@19.2.6)
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.8
+      react-clientside-effect: 1.2.8(react@19.2.8)
+      use-callback-ref: 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      use-sidecar: 1.1.3(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  react-hook-form@7.75.0(react@19.2.6):
+  react-hook-form@7.87.0(react@19.2.8):
     dependencies:
-      react: 19.2.6
+      react: 19.2.8
 
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.6):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@19.2.8):
     dependencies:
-      react: 19.2.6
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.8
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.6):
+  react-remove-scroll@2.7.2(@types/react@19.2.18)(react@19.2.8):
     dependencies:
-      react: 19.2.6
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.8
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.18)(react@19.2.8)
+      react-style-singleton: 2.2.3(@types/react@19.2.18)(react@19.2.8)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      use-callback-ref: 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      use-sidecar: 1.1.3(@types/react@19.2.18)(react@19.2.8)
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
+  react-style-singleton@2.2.3(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.6
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-transition-group@4.4.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.28.4
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   react@19.2.4: {}
 
-  react@19.2.6: {}
+  react@19.2.8: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -12437,30 +12257,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
-      micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
-      remark-stringify: 11.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3
-      micromark-util-types: 2.0.2
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-parse@11.0.0(supports-color@7.2.0):
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -12563,9 +12363,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -12620,9 +12420,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -12636,12 +12436,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@7.2.0):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@7.2.0)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12739,13 +12539,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1(supports-color@7.2.0):
+  sigstore@4.1.1:
     dependencies:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 4.1.1(supports-color@7.2.0)
-      '@sigstore/tuf': 4.0.2(supports-color@7.2.0)
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12767,28 +12567,28 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socket.io-client@4.8.3(supports-color@7.2.0):
+  socket.io-client@4.8.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
-      engine.io-client: 6.6.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.7(supports-color@7.2.0)
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.7(supports-color@7.2.0):
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -12929,12 +12729,10 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
 
   supports-color@7.2.0:
     dependencies:
@@ -12991,11 +12789,11 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tuf-js@4.1.0(supports-color@7.2.0):
+  tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
-      debug: 4.4.3(supports-color@7.2.0)
-      make-fetch-happen: 15.0.6(supports-color@7.2.0)
+      debug: 4.4.3
+      make-fetch-happen: 15.0.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13042,24 +12840,24 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  typescript-eslint@8.62.0(eslint@10.7.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 10.7.0(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@10.7.0)(typescript@5.9.3)
+      eslint: 10.7.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3):
+  typescript-eslint@8.62.0(eslint@9.39.5)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.62.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 9.39.5(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.0(eslint@9.39.5)(typescript@5.9.3)
+      eslint: 9.39.5
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -13166,20 +12964,20 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
+  use-callback-ref@1.3.3(@types/react@19.2.18)(react@19.2.8):
     dependencies:
-      react: 19.2.6
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.6):
+  use-sidecar@1.1.3(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.6
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.18
 
   util-deprecate@1.0.2: {}
 
@@ -13229,10 +13027,10 @@ snapshots:
       sass: 1.90.0
       yaml: 2.9.0
 
-  vue-eslint-parser@10.4.1(eslint@10.7.0(supports-color@7.2.0))(supports-color@7.2.0):
+  vue-eslint-parser@10.4.1(eslint@10.7.0):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.7.0(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 10.7.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0

--- a/real-time-collaboration-comments-outside-of-editor/package.json
+++ b/real-time-collaboration-comments-outside-of-editor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0"

--- a/real-time-collaboration-editor-classic/package.json
+++ b/real-time-collaboration-editor-classic/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0"
   },

--- a/real-time-collaboration-editor-document/package.json
+++ b/real-time-collaboration-editor-document/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0"
   },

--- a/real-time-collaboration-editor-headers-and-footers/package.json
+++ b/real-time-collaboration-editor-headers-and-footers/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0"

--- a/real-time-collaboration-editor-multi-root-for-react/package.json
+++ b/real-time-collaboration-editor-multi-root-for-react/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0",

--- a/real-time-collaboration-editor-multi-root/package.json
+++ b/real-time-collaboration-editor-multi-root/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-collaboration-samples-integrations": "workspace:*",
     "ckeditor5-premium-features": "48.4.0"

--- a/real-time-collaboration-for-angular/package.json
+++ b/real-time-collaboration-for-angular/package.json
@@ -17,7 +17,7 @@
     "@angular/forms": "^20.3.27",
     "@angular/platform-browser": "^20.3.27",
     "@ckeditor/ckeditor5-angular": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0",
     "zone.js": "~0.15.1"

--- a/real-time-collaboration-for-next/package.json
+++ b/real-time-collaboration-for-next/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0",
     "next": "16.3.3",

--- a/real-time-collaboration-for-react/package.json
+++ b/real-time-collaboration-for-react/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0",
     "react": "^19",

--- a/real-time-collaboration-for-vue/package.json
+++ b/real-time-collaboration-for-vue/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@ckeditor/ckeditor5-vue": "8.2.0",
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0",
     "vue": "^3.4.35"

--- a/real-time-collaboration-paragraph-like-classic-editor/package.json
+++ b/real-time-collaboration-paragraph-like-classic-editor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0"
   },

--- a/real-time-collaboration-paragraph-like-multiroot-editor/package.json
+++ b/real-time-collaboration-paragraph-like-multiroot-editor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0"
   },

--- a/real-time-collaboration-with-context/package.json
+++ b/real-time-collaboration-with-context/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "ckbox": "2.13.0",
+    "ckbox": "2.13.1",
     "ckeditor5": "48.4.0",
     "ckeditor5-premium-features": "48.4.0"
   },


### PR DESCRIPTION
### 🚀 Summary

Update ckbox to `v2.13.1`.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4715.

---

### 💡 Additional information

N/A
